### PR TITLE
Changed the API from .co to .dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 
 
-A Node.js helper library for http://swapi.co/ - the Star Wars API
+A Node.js helper library for http://swapi.dev/ - the Star Wars API
 
 
 ## Requirements
@@ -27,17 +27,17 @@ A Node.js helper library for http://swapi.co/ - the Star Wars API
 
 There is a general `get` method that takes a `url`.  So this is also possible:
 
-    swapi.get('https://swapi.co/api/people/?page=2').then((result) => {
+    swapi.get('https://swapi.dev/api/people/?page=2').then((result) => {
         console.log(result);
     });
 
-When you call a "Base URL", like https://swapi.co/api/people/, it will include a `next` and `previous` parameter.  These will be the link to the next/previous page of data.
+When you call a "Base URL", like https://swapi.dev/api/people/, it will include a `next` and `previous` parameter.  These will be the link to the next/previous page of data.
 
 There are helper methods to get results from the next/previous page called `nextPage` and `previousPage`.  Each of these returns a Promise
 
 Here is an example
 
-    swapi.get('https://swapi.co/api/people/').then((result) => {
+    swapi.get('https://swapi.dev/api/people/').then((result) => {
         console.log(result);
         return result.nextPage();
     }).then((result) => {
@@ -65,25 +65,25 @@ For example,  a call to `getPerson(1)` might return this json:
         "eye_color": "blue",
         "birth_year": "19BBY",
         "gender": "male",
-        "homeworld": "https://swapi.co/api/planets/1/",
+        "homeworld": "https://swapi.dev/api/planets/1/",
         "films": [
-            "https://swapi.co/api/films/1/",
-            "https://swapi.co/api/films/2/",
-            "https://swapi.co/api/films/3/",
-            "https://swapi.co/api/films/6/"
+            "https://swapi.dev/api/films/1/",
+            "https://swapi.dev/api/films/2/",
+            "https://swapi.dev/api/films/3/",
+            "https://swapi.dev/api/films/6/"
         ],
         "species": [],
         "vehicles": [
-            "https://swapi.co/api/vehicles/14/",
-            "https://swapi.co/api/vehicles/30/"
+            "https://swapi.dev/api/vehicles/14/",
+            "https://swapi.dev/api/vehicles/30/"
         ],
         "starships": [
-            "https://swapi.co/api/starships/12/",
-            "https://swapi.co/api/starships/22/"
+            "https://swapi.dev/api/starships/12/",
+            "https://swapi.dev/api/starships/22/"
         ],
         "created": "2014-12-09T13:50:51.644000Z",
         "edited": "2014-12-20T21:17:56.891000Z",
-        "url": "https://swapi.co/api/people/1/"
+        "url": "https://swapi.dev/api/people/1/"
     }
 
 taking "homeworld" as an example,  you can now call `getHomeworld()`, which will return a Promise
@@ -106,34 +106,34 @@ This might produce some json like this:
         "surface_water": "1",
         "population": "200000",
         "residents": [
-            "https://swapi.co/api/people/1/",
-            "https://swapi.co/api/people/2/",
-            "https://swapi.co/api/people/4/",
-            "https://swapi.co/api/people/6/",
-            "https://swapi.co/api/people/7/",
-            "https://swapi.co/api/people/8/",
-            "https://swapi.co/api/people/9/",
-            "https://swapi.co/api/people/11/",
-            "https://swapi.co/api/people/43/",
-            "https://swapi.co/api/people/62/"
+            "https://swapi.dev/api/people/1/",
+            "https://swapi.dev/api/people/2/",
+            "https://swapi.dev/api/people/4/",
+            "https://swapi.dev/api/people/6/",
+            "https://swapi.dev/api/people/7/",
+            "https://swapi.dev/api/people/8/",
+            "https://swapi.dev/api/people/9/",
+            "https://swapi.dev/api/people/11/",
+            "https://swapi.dev/api/people/43/",
+            "https://swapi.dev/api/people/62/"
         ],
         "films": [
-            "https://swapi.co/api/films/1/",
-            "https://swapi.co/api/films/3/",
-            "https://swapi.co/api/films/4/",
-            "https://swapi.co/api/films/5/",
-            "https://swapi.co/api/films/6/"
+            "https://swapi.dev/api/films/1/",
+            "https://swapi.dev/api/films/3/",
+            "https://swapi.dev/api/films/4/",
+            "https://swapi.dev/api/films/5/",
+            "https://swapi.dev/api/films/6/"
         ],
         "created": "2014-12-09T13:50:49.641000Z",
         "edited": "2014-12-21T20:48:04.175778Z",
-        "url": "https://swapi.co/api/planets/1/"
+        "url": "https://swapi.dev/api/planets/1/"
     }
 
 ### Note
 
 This API tries to follow the API for the Python helper lib here: https://github.com/phalt/swapi-python
 
-For documentation on the Star Wars API, check out their docs:  http://swapi.co/documentation
+For documentation on the Star Wars API, check out their docs:  http://swapi.dev/documentation
 
 ## Breaking Changes
 

--- a/lib/swapi-node.js
+++ b/lib/swapi-node.js
@@ -3,7 +3,7 @@
 const request = require('request');
 const util = require('./util');
 
-const BASE_URL = 'https://swapi.co/api/';
+const BASE_URL = 'https://swapi.dev/api/';
 
 function sendRequest (options) {
   return new Promise((resolve, reject) => {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "swapi-node",
   "version": "0.5.0",
-  "description": "A Node.js helper library for swapi.co",
+  "description": "A Node.js helper library for SWAPI",
   "main": "index.js",
   "engines": {
     "node": ">= 10.14.0"

--- a/test/swapi-api-tests.js
+++ b/test/swapi-api-tests.js
@@ -5,22 +5,24 @@ const swapi = require('../lib/swapi-node.js');
 const {version} = require('../package.json');
 const test = require('tape');
 
+const BASE_URL = 'https://swapi.dev/api';
+
 nock.disableNetConnect();
 
 test('GET a resource', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/?page=2')
     .reply(200, {});
 
-  await swapi.get('https://swapi.co/api/people/?page=2');
+  await swapi.get(`${BASE_URL}/people/?page=2`);
   t.pass('return success');
   t.end();
 });
 
 test('GET People - Return a Promise', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/1')
@@ -33,7 +35,7 @@ test('GET People - Return a Promise', async t => {
 });
 
 test('GET People - using options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/1')
@@ -45,7 +47,7 @@ test('GET People - using options', async t => {
 });
 
 test('GET People - error returned', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/1')
@@ -59,7 +61,7 @@ test('GET People - error returned', async t => {
 });
 
 test('GET films', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/films/1')
@@ -72,7 +74,7 @@ test('GET films', async t => {
 });
 
 test('GET films - with options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/films/1')
@@ -84,7 +86,7 @@ test('GET films - with options', async t => {
 });
 
 test('GET films - with error', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/films/1')
@@ -99,7 +101,7 @@ test('GET films - with error', async t => {
 });
 
 test('GET starship', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/starships/1')
@@ -112,7 +114,7 @@ test('GET starship', async t => {
 });
 
 test('GET starship - with options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/starships/1')
@@ -124,7 +126,7 @@ test('GET starship - with options', async t => {
 });
 
 test('GET starship - with error', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/starships/1')
@@ -138,7 +140,7 @@ test('GET starship - with error', async t => {
 });
 
 test('GET vehicles', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/vehicles/1')
@@ -151,7 +153,7 @@ test('GET vehicles', async t => {
 });
 
 test('GET vehicles - with options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/vehicles/1')
@@ -163,7 +165,7 @@ test('GET vehicles - with options', async t => {
 });
 
 test('GET vehicles - with error', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/vehicles/1')
@@ -178,7 +180,7 @@ test('GET vehicles - with error', async t => {
 });
 
 test('GET species', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/species/1')
@@ -191,7 +193,7 @@ test('GET species', async t => {
 });
 
 test('GET species - with options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/species/1')
@@ -203,7 +205,7 @@ test('GET species - with options', async t => {
 });
 
 test('GET species - with error', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/species/1')
@@ -218,7 +220,7 @@ test('GET species - with error', async t => {
 });
 
 test('GET planets', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/planets/1')
@@ -231,7 +233,7 @@ test('GET planets', async t => {
 });
 
 test('GET planets - with options', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/planets/1')
@@ -243,7 +245,7 @@ test('GET planets - with options', async t => {
 });
 
 test('GET planets - with error', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/planets/1')

--- a/test/swapi-paging-test.js
+++ b/test/swapi-paging-test.js
@@ -5,29 +5,31 @@ const swapi = require('../lib/swapi-node.js');
 const {version} = require('../package.json');
 const test = require('tape');
 
+const BASE_URL = 'https://swapi.dev/api';
+
 nock.disableNetConnect();
 
 test('returned value should have a nextPage added', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/')
     .reply(200, {
       count: 82,
-      next: 'https://swapi.co/api/people/?page=2',
+      next: `${BASE_URL}/people/?page=2`,
       previous: null
     });
 
-  const result = await swapi.get('https://swapi.co/api/people/');
+  const result = await swapi.get(`${BASE_URL}/people/`);
   t.equal(typeof result.nextPage, 'function', 'should be a next function');
 
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/?page=2')
     .reply(200, {
       count: 82,
-      next: 'https://swapi.co/api/people/?page=3',
+      next: `${BASE_URL}/people/?page=3`,
       previous: null
     });
 
@@ -37,25 +39,25 @@ test('returned value should have a nextPage added', async t => {
 });
 
 test('returned value should have a previousPage added', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/')
     .reply(200, {
       count: 82,
-      previous: 'https://swapi.co/api/people/?page=2'
+      previous: `${BASE_URL}/people/?page=2`
     });
 
-  const result = await swapi.get('https://swapi.co/api/people/');
+  const result = await swapi.get(`${BASE_URL}/people/`);
   t.equal(typeof result.previousPage, 'function', 'should be a next function');
 
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/?page=2')
     .reply(200, {
       count: 82,
-      previous: 'https://swapi.co/api/people/?page=1'
+      previous: `${BASE_URL}/people/?page=1`
     });
 
   await result.nextPage();

--- a/test/swapi-subresources-test.js
+++ b/test/swapi-subresources-test.js
@@ -7,20 +7,22 @@ const test = require('tape');
 
 nock.disableNetConnect();
 
+const BASE_URL = 'https://swapi.dev/api';
+
 test('property with link should have a corresponding getter', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/1')
     .reply(200, {
       name: 'Luke Skywalker',
-      homeworld: 'https://swapi.co/api/planets/1/'
+      homeworld: `${BASE_URL}/planets/1/`
     });
 
   const result = await swapi.getPerson(1);
   t.equal((typeof result.getHomeworld === 'function'), true, 'should be a function');
 
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/planets/1/')
@@ -34,13 +36,13 @@ test('property with link should have a corresponding getter', async t => {
 });
 
 test('property with out link should have a corresponding getter anyway', async t => {
-  nock('https://swapi.co/api/')
+  nock(`${BASE_URL}/`)
     .matchHeader('User-Agent', 'swapi-node')
     .matchHeader('SWAPI-Node-Version', version)
     .get('/people/1')
     .reply(200, {
       name: 'Luke Skywalker',
-      homeworld: 'https://swapi.co/api/planets/1/'
+      homeworld: `${BASE_URL}/planets/1/`
     });
 
   const result = await swapi.getPerson(1);


### PR DESCRIPTION
The swapi.co API does not work anymore but someone did a clone at swapi.dev. This PR changes all references to swapi.co to swapi.dev instead. The tests were also changed to have a single BASE_URL that is reused in case this happens again.